### PR TITLE
Sync unstable → main (vulnix + disk-pressure + dependabot)

### DIFF
--- a/.github/workflows/_vulnix.yml
+++ b/.github/workflows/_vulnix.yml
@@ -29,6 +29,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # GitHub-hosted ubuntu-latest ships with ~14GB free on /. The
+      # NixOS toplevel build pulls many GB of derivations and has
+      # blown disk on real PRs (PR #404 today: "No space left on
+      # device" mid-build). Drop unused tooling and the .NET cache
+      # before nix touches the disk. Frees ~30GB on typical runners.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
         with:

--- a/.github/workflows/_vulnix.yml
+++ b/.github/workflows/_vulnix.yml
@@ -205,8 +205,10 @@ jobs:
           # dev gh calls eat. The REST search endpoint has its own
           # 5000/hr budget and uses /search/issues. Same for create
           # and comment (REST POST /repos/.../issues and .../comments).
-          gh label create security  --repo "$REPO" --color B60205 --description "Security-related issue" 2>/dev/null || true
-          gh label create automated --repo "$REPO" --color BFD4F2 --description "Created by automation"  2>/dev/null || true
+          # gh label create uses GraphQL internally; go straight to REST.
+          # 422 on duplicate is fine — that's "label exists already".
+          gh api -X POST "repos/${REPO}/labels" -f name=security  -f color=B60205 -f description="Security-related issue" 2>/dev/null || true
+          gh api -X POST "repos/${REPO}/labels" -f name=automated -f color=BFD4F2 -f description="Created by automation"  2>/dev/null || true
           # URL-encode the title for the search query.
           Q=$(printf '%s' "$TITLE" | jq -sRr @uri)
           EXISTING_NUM=$(gh api "search/issues?q=repo:${REPO}+is:issue+label:security+in:title+\"${Q}\"" --jq '.items[0].number // empty')

--- a/.github/workflows/_vulnix.yml
+++ b/.github/workflows/_vulnix.yml
@@ -200,25 +200,30 @@ jobs:
             echo
             cat findings-body.md
           } > issue-body.md
+          # REST instead of GraphQL: `gh issue list --search` uses
+          # GraphQL which shares the per-user 5000/hr cap that ad-hoc
+          # dev gh calls eat. The REST search endpoint has its own
+          # 5000/hr budget and uses /search/issues. Same for create
+          # and comment (REST POST /repos/.../issues and .../comments).
           gh label create security  --repo "$REPO" --color B60205 --description "Security-related issue" 2>/dev/null || true
           gh label create automated --repo "$REPO" --color BFD4F2 --description "Created by automation"  2>/dev/null || true
-          EXISTING=$(gh issue list --repo "$REPO" --label security --state all \
-            --search "in:title \"${TITLE}\"" \
-            --json number,state --jq '.[0]')
-          if [ -n "$EXISTING" ]; then
-            NUM=$(echo "$EXISTING" | jq -r .number)
-            STATE=$(echo "$EXISTING" | jq -r .state)
-            if [ "$STATE" = "CLOSED" ]; then
-              gh issue reopen "$NUM" --repo "$REPO"
+          # URL-encode the title for the search query.
+          Q=$(printf '%s' "$TITLE" | jq -sRr @uri)
+          EXISTING_NUM=$(gh api "search/issues?q=repo:${REPO}+is:issue+label:security+in:title+\"${Q}\"" --jq '.items[0].number // empty')
+          EXISTING_STATE=$(gh api "search/issues?q=repo:${REPO}+is:issue+label:security+in:title+\"${Q}\"" --jq '.items[0].state // empty')
+          if [ -n "$EXISTING_NUM" ]; then
+            NUM="$EXISTING_NUM"
+            if [ "$EXISTING_STATE" = "closed" ]; then
+              gh api -X PATCH "repos/${REPO}/issues/${NUM}" -f state=open >/dev/null
             fi
-            gh issue comment "$NUM" --repo "$REPO" --body-file issue-body.md
+            gh api -X POST "repos/${REPO}/issues/${NUM}/comments" -f body="$(cat issue-body.md)" >/dev/null
           else
-            NUM=$(gh issue create --repo "$REPO" \
-              --title "$TITLE" \
-              --body-file issue-body.md \
-              --label security \
-              --label automated \
-              --assignee jasonodoom | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+')
+            NUM=$(gh api -X POST "repos/${REPO}/issues" \
+              -f title="$TITLE" \
+              -f body="$(cat issue-body.md)" \
+              -f 'labels[]=security' \
+              -f 'labels[]=automated' \
+              -f 'assignees[]=jasonodoom' --jq '.number')
           fi
           echo "issue_number=$NUM" >> "$GITHUB_OUTPUT"
           echo "issue_url=https://github.com/${REPO}/issues/$NUM" >> "$GITHUB_OUTPUT"
@@ -240,4 +245,7 @@ jobs:
           # private repo to avoid publishing a full vulnerability map
           # of running infra on a public PR.
           BODY="vulnix found CVEs in this PR's closure for **${HOST_NAME}**. Details (private): ${ISSUE_URL}"
-          gh pr comment "${PR_NUMBER}" --body "$BODY"
+          # REST instead of GraphQL gh pr comment (uses /repos/.../issues/N/comments;
+          # PRs are issues under the hood).
+          gh api -X POST "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            -f body="$BODY" >/dev/null

--- a/.github/workflows/auto-pr-unstable-to-main.yml
+++ b/.github/workflows/auto-pr-unstable-to-main.yml
@@ -48,7 +48,13 @@ jobs:
       - name: Check if PR already exists
         id: check-pr
         run: |
-          PR_EXISTS=$(gh pr list --head unstable --base main --state open --json number --jq 'length')
+          # REST instead of GraphQL: `gh pr list` uses GraphQL which
+          # shares the same 5000/hr per-user budget that ad-hoc dev
+          # work eats. The REST `/pulls` endpoint has its own
+          # 5000/hr core budget. Failing this step skips the entire
+          # auto-PR (and the operator has to open by hand) which is
+          # exactly what bit us on 2026-05-26.
+          PR_EXISTS=$(gh api "repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:unstable&base=main&state=open" --jq 'length')
           echo "pr_exists=$PR_EXISTS" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
@@ -183,8 +189,9 @@ jobs:
       - name: Create Pull Request
         if: steps.check-pr.outputs.pr_exists == '0' && steps.check-commits.outputs.needs_pr == 'true'
         run: |
-          # Check if PR already exists (guard against race conditions)
-          EXISTING_PR=$(gh pr list --head unstable --base main --state open --json number --jq '.[0].number // empty')
+          # Check if PR already exists (guard against race conditions).
+          # REST instead of GraphQL — see "Check if PR already exists" step.
+          EXISTING_PR=$(gh api "repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:unstable&base=main&state=open" --jq '.[0].number // empty')
           if [ -n "$EXISTING_PR" ]; then
             echo "PR #$EXISTING_PR already exists, skipping creation"
             exit 0
@@ -257,5 +264,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         run: |
           sleep 2
-          PR_NUMBER=$(gh pr list --head unstable --base main --json number -q '.[0].number')
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:unstable&base=main&state=open" --jq '.[0].number')
           gh pr merge "${PR_NUMBER}" --auto --merge

--- a/.github/workflows/vulnix-scan.yml
+++ b/.github/workflows/vulnix-scan.yml
@@ -30,3 +30,9 @@ jobs:
       host_dir: ${{ matrix.dir }}
       host_name: ${{ matrix.host }}
       pr_number: ${{ github.event.pull_request.number && format('{0}', github.event.pull_request.number) || '' }}
+    # Reusable workflows don't see caller secrets by default; the
+    # vulnix scan needs VULNIX_REPO_TOKEN (PAT with cross-repo write
+    # to nixos-vulnix-private) for the tracking-issue + pointer-
+    # comment steps. Without this line both steps fail with empty
+    # GH_TOKEN even though the secret is set at the repo level.
+    secrets: inherit


### PR DESCRIPTION
## Summary

Unstable has the days nixos-configs work that should land on main:

- 5d3db7e nixos: disk-pressure guards on perdurabo + congo (nix.gc daily/7d, min-free/max-free, hourly disk-pressure-warn timer)
- eb7996f vulnix: VULNIX_REPO_TOKEN for PR pointer comment
- 84590dd dependabot: stop bumping nixpkgs-wrangler-pin
- f45a7c5 vulnix: pass caller secrets into reusable workflow
- 4790e35 vulnix: free runner disk before building toplevel

The auto-PR-unstable-to-main workflow has been failing on the latest pushes due to GraphQL rate-limit on `gh pr list` — worth fixing separately, opened by hand for now.

## Test plan
- [ ] build-with-cache jobs pass on perdurabo + congo + theophany
- [ ] vulnix scan completes