### PR TITLE
Merge unstable to main

### DIFF
--- a/.github/workflows/vega-cache.yml
+++ b/.github/workflows/vega-cache.yml
@@ -55,7 +55,7 @@ jobs:
           persist-credentials: false
       # The agent installs Nix, builds the installable, and pushes only paths the
       # upstream cache does not already serve.
-      - uses: Ad-Astra-Computing/vega-agent/agent@376688ed160aca2236ddf848d438826181439635
+      - uses: Ad-Astra-Computing/vega-agent/agent@3326085b14503a6a86bd482a140c68fc54f2d0a0
         with:
           installable: "${{ github.workspace }}/${{ matrix.host }}#${{ matrix.attr }}"
           control-plane: https://vega-cache.dev

--- a/.github/workflows/vega-cache.yml
+++ b/.github/workflows/vega-cache.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 concurrency:
   group: vega-cache-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 jobs:
   cache:
     runs-on: ${{ matrix.os }}
@@ -55,7 +55,7 @@ jobs:
           persist-credentials: false
       # The agent installs Nix, builds the installable, and pushes only paths the
       # upstream cache does not already serve.
-      - uses: Ad-Astra-Computing/vega-agent/agent@620fb2b6c95feb52f6a50df8be82c9d0a019852a
+      - uses: Ad-Astra-Computing/vega-agent/agent@376688ed160aca2236ddf848d438826181439635
         with:
           installable: "${{ github.workspace }}/${{ matrix.host }}#${{ matrix.attr }}"
           control-plane: https://vega-cache.dev


### PR DESCRIPTION
## Changes in unstable branch

This PR merges changes from unstable to main after CI validation.

### Commits in this PR:
```
3c64f1a Auto-sync main to unstable
a3b65e1 vega-cache: bump agent to v0.2.0 (376688e); don't cancel in-progress cache runs
```

### CI Checks Required:
- build-with-garnix
- format-check
- security-check
- test-gnome-desktop

---
Auto-generated PR from unstable branch