### PR TITLE
Merge unstable to main

### DIFF
--- a/.github/workflows/vega-cache.yml
+++ b/.github/workflows/vega-cache.yml
@@ -92,3 +92,7 @@ jobs:
           VEGA_URL: https://vega-cache.dev
           VEGA_SKIP_UPSTREAM: "true"
           VEGA_REUSE_CACHE: "true"
+          # Upload one NAR at a time: the agent buffers each compressed NAR in
+          # memory, so the default of 4 OOM-kills the container on this heavy
+          # closure. Can be raised once the agent streams uploads (vega-agent).
+          VEGA_UPLOAD_CONCURRENCY: "1"


### PR DESCRIPTION
## Changes in unstable branch

This PR merges changes from unstable to main after CI validation.

### Commits in this PR:
```
eb1ac06 Auto-sync main to unstable
bf98479 vega-cache: cap perdurabo upload concurrency to 1 (avoid OOM)
```

### CI Checks Required:
- build-with-garnix
- format-check
- security-check
- test-gnome-desktop

---
Auto-generated PR from unstable branch