### PR TITLE
Merge unstable to main

### DIFF
--- a/framework-desktop/flake.lock
+++ b/framework-desktop/flake.lock
@@ -293,11 +293,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1781243308,
-        "narHash": "sha256-djohjN5HUMDIkfRwF5DvICc9BVHbBgQiMbm0hiOtdF8=",
+        "lastModified": 1781245669,
+        "narHash": "sha256-kbVCdRcll+JaelSqVNHhW38oQD5dctDLi/vRWT9t6/M=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "0a40512051adba7253d46793dfb428ebafcfa500",
+        "rev": "10a7a6c07357af3351455eb4b3638418a4e76fec",
         "type": "github"
       },
       "original": {

--- a/framework-desktop/flake.nix
+++ b/framework-desktop/flake.nix
@@ -143,6 +143,7 @@
         ./modules/bosun-browser-microvm.nix
         ./modules/bosun.nix
         ./modules/agentic-tmux.nix
+        { services.agenticTmux.enable = true; }
       ];
     };
   in

--- a/framework-desktop/flake.nix
+++ b/framework-desktop/flake.nix
@@ -62,10 +62,27 @@
         nodejsPkg = nodejsPkgFor system;
       };
       modules = [
-        ({ config, pkgs, ... }: {
+        ({ config, lib, pkgs, ... }: {
           nixpkgs.overlays = [
             self.overlays.default
           ];
+
+          # The Determinate NixOS module assigns
+          # `nix.package = inputs.nix.packages.<system>.default` (its
+          # own nix-src build). That nix's functional test suite needs
+          # unprivileged user namespaces to drive `unshare`, which the
+          # self-hosted vega container can't give it — the tests crash
+          # and Nix leaves /homeless-shelter behind. I reach into the
+          # same input Determinate uses and strip the check phase, so
+          # CI doesn't try to rebuild + test nix from source on the
+          # cache-miss path. Referencing config.nix.package here would
+          # self-recurse, so I source from the transitive flake input.
+          nix.package = lib.mkForce (
+            inputs.determinate.inputs.nix.packages.${pkgs.stdenv.system}.default.overrideAttrs (_: {
+              doCheck = false;
+              doInstallCheck = false;
+            })
+          );
         })
 
         # Hardware configuration

--- a/framework-desktop/overlays/default.nix
+++ b/framework-desktop/overlays/default.nix
@@ -51,13 +51,14 @@ final: prev: {
     '';
   });
 
-  # The functional test suite calls `unshare` to set up per-test
-  # namespace sandboxes. CI runners that lack
-  # kernel.unprivileged_userns_clone (the self-hosted vega container)
-  # fail every test with "Operation not permitted". Disable the check
-  # phase so the closure can be built; nix itself is unaffected.
-  nix = prev.nix.overrideAttrs (old: {
+  # nixpkgs-review pulls nixpkgs' nix-2.34.7 into the closure (it
+  # shells out to nix during a review). That nix runs the same
+  # functional test suite under `unshare`, which fails on the
+  # sandbox-less vega container. Mirror the Determinate-nix override
+  # in framework-desktop/flake.nix for the nixpkgs nix too.
+  nix = prev.nix.overrideAttrs (_: {
     doCheck = false;
     doInstallCheck = false;
   });
+
 }


### PR DESCRIPTION
## Changes in unstable branch

This PR merges changes from unstable to main after CI validation.

### Commits in this PR:
```
cfe9d72 chore: update flake.lock files
17c521c Auto-sync main to unstable
50693c0 framework-desktop: override Determinate nix.package to skip checkPhase
```

### CI Checks Required:
- build-with-garnix
- format-check
- security-check
- test-gnome-desktop

---
Auto-generated PR from unstable branch