### PR TITLE
Merge unstable to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,14 @@ jobs:
         # crosses the threshold, which is the difference between perdurabo
         # (five microvm closures + their erofs images built sequentially)
         # fitting on the runner or not. Numbers in bytes; 5 GiB / 15 GiB.
+        # #82: if min-free isn't enough on a future microvm addition,
+        # the trap below captures df at the moment of failure so we can
+        # tell disk-exhaustion vs evaluation/build-time errors apart
+        # without re-running the job with verbose logging. The
+        # structural fallback (skip erofs disk-image attrs when low
+        # on disk) is pending — would require splitting toplevel
+        # into closure-only + image targets.
+        set +e
         nix build .#nixosConfigurations.${{ matrix.config }}.config.system.build.toplevel \
           --accept-flake-config \
           --option max-jobs $MAX_JOBS \
@@ -135,6 +143,18 @@ jobs:
           --option min-free $((5 * 1024 * 1024 * 1024)) \
           --option max-free $((15 * 1024 * 1024 * 1024)) \
           --impure
+        BUILD_RC=$?
+        set -e
+        if [ $BUILD_RC -ne 0 ]; then
+          echo "=== Build failed (rc=$BUILD_RC) — disk state at failure ==="
+          df -h
+          AVAIL_MIB=$(df -BM --output=avail / | tail -1 | tr -dc 0-9)
+          if [ "$AVAIL_MIB" -lt 2048 ]; then
+            echo "::error::Build failed with $AVAIL_MIB MiB free on / — min-free=5GiB was insufficient."
+            echo "::error::Consider raising min-free, adding a free-disk-space pass, or splitting the build to skip erofs disk-image attrs (#82)."
+          fi
+          exit $BUILD_RC
+        fi
 
         # Immediate cleanup after build
         nix-collect-garbage --delete-older-than 1d

--- a/apple-macbook-air-m2/modules/darwin-auto-update.nix
+++ b/apple-macbook-air-m2/modules/darwin-auto-update.nix
@@ -65,6 +65,26 @@
         exit 0
       fi
 
+      # Pre-flight homebrew + masApps (#77). nix-darwin runs
+      # `brew bundle` during activation; if `mas` is missing, the
+      # App Store account is not signed in, or one of the masApps
+      # IDs is no longer purchasable, the whole rebuild fails.
+      # Log the situation up front so the eventual failure issue
+      # tells the operator exactly what to fix, and skip the
+      # rebuild rather than chasing a known-bad activation.
+      if [ -x /opt/homebrew/bin/mas ]; then
+        MAS_ACCOUNT=$(/opt/homebrew/bin/mas account 2>&1 || true)
+        if [ -z "$MAS_ACCOUNT" ] || echo "$MAS_ACCOUNT" | grep -qiE "not signed in|no account"; then
+          log "WARNING: mas account not signed in (output: $MAS_ACCOUNT)"
+          log "Skipping rebuild — masApps activation will fail until you sign in to the App Store"
+          create_failure_issue "mas account not signed in. Open App Store, sign in, then re-run darwin-auto-update." "preflight" || log "Failed to create GitHub issue"
+          exit 0
+        fi
+        log "mas account: $MAS_ACCOUNT"
+      else
+        log "mas binary not yet installed (first activation will install it)"
+      fi
+
       log "Starting darwin auto-update"
 
       # Clone or update repo
@@ -114,7 +134,18 @@
       else
         log "darwin-rebuild failed"
         LOG_TAIL=$(tail -100 "$BUILD_OUTPUT")
-        create_failure_issue "$LOG_TAIL" "$CURRENT_COMMIT" || log "Failed to create GitHub issue"
+        # #77 classify the failure so the issue title points at the
+        # right culprit. brew/mas failures are common operator-
+        # actionable cases (App Store re-auth, masApp removed,
+        # cask name changed); a tagged title lets the operator
+        # triage at a glance instead of opening every nightly
+        # issue blind.
+        if echo "$LOG_TAIL" | grep -qE "mas (install|download).*(fail|error)|brew bundle.*(fail|error)|cask.*not found"; then
+          ISSUE_PREFIX="[homebrew]"
+        else
+          ISSUE_PREFIX="[rebuild]"
+        fi
+        create_failure_issue "$ISSUE_PREFIX $LOG_TAIL" "$CURRENT_COMMIT" || log "Failed to create GitHub issue"
         rm -f "$BUILD_OUTPUT"
         exit 1
       fi


### PR DESCRIPTION
## Changes in unstable branch

This PR merges changes from unstable to main after CI validation.

### Commits in this PR:
```
5cdf2b7 Auto-sync main to unstable
08d9ae4 ci: surface disk-state at perdurabo build failure (#82 prep)
ca4515f darwin-auto-update: pre-flight mas account + tag homebrew vs rebuild failures (#77)
```

### CI Checks Required:
- build-with-garnix
- format-check
- security-check
- test-gnome-desktop

---
Auto-generated PR from unstable branch